### PR TITLE
feat(backend): Implement password reset and configure email service

### DIFF
--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -33,7 +33,7 @@ def send_verification_email(user, request):
     send_mail(
         email_subject,
         email_body,
-        'noreply@yourdomain.com',
+        settings.DEFAULT_FROM_EMAIL,
         [user.email],
         fail_silently=False,
     )
@@ -107,7 +107,7 @@ class PasswordResetRequestView(generics.GenericAPIView):
             send_mail(
                 email_subject,
                 email_body,
-                'noreply@yourdomain.com',
+                settings.DEFAULT_FROM_EMAIL,
                 [user.email],
                 fail_silently=False,
             )
@@ -125,7 +125,9 @@ class PasswordResetConfirmView(generics.GenericAPIView):
     serializer_class = SetNewPasswordSerializer
 
     def patch(self, request, *args, **kwargs):
-        serializer = self.get_serializer(data=request.data)
+        serializer = self.get_serializer(
+            data=request.data, context={'uidb64': kwargs['uidb64'], 'token': kwargs['token']}
+        )
         serializer.is_valid(raise_exception=True)
         return Response({'message': 'Password reset successful'}, status=status.HTTP_200_OK)
 

--- a/backend/auth_project/settings.py
+++ b/backend/auth_project/settings.py
@@ -141,4 +141,16 @@ REST_FRAMEWORK = {
 # Email backend
 # https://docs.djangoproject.com/en/5.2/topics/email/
 
+# For development, all emails are printed to the console.
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+DEFAULT_FROM_EMAIL = "noreply@example.com"
+
+# For production, you should use a transactional email service.
+# Example for SMTP:
+# EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+# EMAIL_HOST = 'smtp.example.com'
+# EMAIL_PORT = 587
+# EMAIL_USE_TLS = True
+# EMAIL_HOST_USER = 'your-smtp-username'  # Recommended to use environment variables
+# EMAIL_HOST_PASSWORD = 'your-smtp-password' # Recommended to use environment variables
+# DEFAULT_FROM_EMAIL = 'noreply@yourdomain.com'


### PR DESCRIPTION
This commit addresses two issues in the Django backend:

1.  **Fixes the password reset confirmation logic.** The `PasswordResetConfirmView` was a stub and did not actually update the user's password. This has been fixed by passing the `uidb64` and `token` from the URL to the `SetNewPasswordSerializer` via the context. The serializer now correctly validates the token and saves the new password.

2.  **Configures the email service.** The email `from` address was previously hardcoded. This has been updated to use Django's `settings.DEFAULT_FROM_EMAIL`. The settings file has been updated to use the console email backend for development and now includes commented-out instructions for configuring a production SMTP service.

No backend tests were run as the test suite was empty.